### PR TITLE
Add circleci to run tests and snyk go module scan

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,24 @@
+version: 2.1
+orbs:
+  snyk: snyk/snyk@2.1.0
+jobs:
+  build-and-test:
+    machine:
+      image: default
+    steps:
+      - run: docker pull golang:1.20
+      - checkout
+      - run: "docker run --privileged=true
+            -v /home/circleci/project/:/go/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
+            -w /go/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
+            golang:1.20 sh -c 'git config --global url.\"https://'$GITHUB_USERNAME':'$GITHUB_PASSWORD'@github.com\".insteadOf \"https://github.com\" && go env -w GOPRIVATE=github.com/goalbook && go mod download && go test -v -p 1 ./...'"
+      - snyk/scan:
+          fail-on-issues: false
+          organization: goalbook
+workflows:
+  version: 2
+  build-and-test-workflow:
+    jobs:
+      - build-and-test:
+          context:
+            - snyk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 orbs:
   snyk: snyk/snyk@2.1.0
 jobs:
-  build-and-test:
+  test-and-snyk:
     machine:
       image: default
     steps:
@@ -19,6 +19,6 @@ workflows:
   version: 2
   build-and-test-workflow:
     jobs:
-      - build-and-test:
+      - test-and-snyk:
           context:
             - snyk


### PR DESCRIPTION
# Issue
[Asana task ](https://app.asana.com/0/1155441960274388/1207508836199467/f)- add snyk to circleci for go repos since it has more accurate results than through the github integration 

# Proposed Solution
- add circleci integration for this repo
- Use snyk orb to run snyk in circleci
<img width="1257" alt="Screenshot 2024-06-12 at 12 01 15 PM" src="https://github.com/dhirenb/easyroute/assets/5439169/5556eea2-c0f2-41b6-aac3-58fe94f1f18d">




# Testing
## Automated
N/A
## Manual
See the build pass in circleCI here: https://app.circleci.com/pipelines/github/goalbook/easyroute/3/workflows/441b4134-7ce3-4517-862d-b9132247234e/jobs/3
See snyk project here: https://app.snyk.io/org/goalbook/project/cbb6e43b-5125-4cda-a4db-c2d41c8f546e

# Considerations
## Security
Allows us to support resolving security vulnerabilities in a more organized way

## Data Privacy
N/A

## Accessibility
N/A

## Performance
N/A


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207516427594512